### PR TITLE
Fixed incorrect readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ first to download ColdFusion 11 installer and latest patches. Then build the Doc
 
 And run it with:
 
-    docker run -d -p 80:80 -v /var/www:/var/www cf10
+    docker run -d -p 80:80 -v /var/www:/var/www cf11


### PR DESCRIPTION
I'm assuming that this should be updated...it looks like the instructions were copied for the docker-coldfusion10 container, but all appropriate updates were not made.